### PR TITLE
Add Worlds to the isolation section

### DIFF
--- a/specification/src/chapter1.adoc
+++ b/specification/src/chapter1.adoc
@@ -4,18 +4,18 @@
 == Introduction
 
 This specification provides normative requirements for building
-secure RISC-V systems using RISC-V security building blocks, non-normative 
+secure RISC-V systems using RISC-V security building blocks, non-normative
 examples that select a subset of these normative requirements appropriate for a
-use case, and non-normative use case specific guidelines. 
+use case, and non-normative use case specific guidelines.
 
-It is aimed at developers of RISC-V technical specifications, as well as at 
+It is aimed at developers of RISC-V technical specifications, as well as at
 designers of secure RISC-V systems. It is intended to be referenced by other
-documentation that will define a specific subset of requirements applicable 
+documentation that will define a specific subset of requirements applicable
 for a given use case, certification regime, platform or profile.
 
 The non-normative example use cases provided are based on commonly used
 security deployment models. These are not intended to be exhaustive but are
-common enough to represent a wide range of deployments of secure products. 
+common enough to represent a wide range of deployments of secure products.
 They are accompanied by an appropriate set of use case specific security
 guidelines which are intended to help readers implement secure products for
 their specific use cases.
@@ -43,13 +43,13 @@ Mapping documentation or protection profiles may also directly reference this
 document.
 
 This specification does not contain threat modelling or security assessment of
-the RISC-V ISA specifications, non ISA specifications, profile specifications or 
+the RISC-V ISA specifications, non ISA specifications, profile specifications or
 extensions (RISC-V technical specifications). RISC-V technical specifications
-are expected to use the Security Model as a guide to develop their own specific 
-security analysis, including formal threat modeling where appropriate. For this 
-purpose, all guidelines in this document are labelled to enable referencing from 
-other specifications. Specific security analysis in the context of a RISC-V technical 
-specification may require testing and a proof of concept as per normal RISC-V 
+are expected to use the Security Model as a guide to develop their own specific
+security analysis, including formal threat modeling where appropriate. For this
+purpose, all guidelines in this document are labelled to enable referencing from
+other specifications. Specific security analysis in the context of a RISC-V technical
+specification may require testing and a proof of concept as per normal RISC-V
 development processes for RISC-V technical specifications.
 
 Security is an evolving area where new use cases and new threats can emerge at
@@ -67,8 +67,8 @@ required.
 This is a normative specification. However, the specification does not mandate
 the adoption of any requirements. These requirements are intended to be
 referenced by current and future specifications, both RISC-V and external
-specifications,  where a subset of the normative requirements, specific to the 
-use case, certification regime, platform or profile under consideration will be 
+specifications,  where a subset of the normative requirements, specific to the
+use case, certification regime, platform or profile under consideration will be
 documented. A set of in-scope security threats are also defined in this specification.
 These threats are intended to be referenced by the threat models of current and future
 specifications, both RISC-V and external specifications. This specification expresses
@@ -107,8 +107,8 @@ may also be used to reference sources that are the origin of the requirement.
 
 NOTE: All normative requirements are expressed as mandatory and some sections may
 include mutually exclusive requirements. A use case specific requirements document
-must define if a requirement is recommended or mandatory, as well as any allowable 
-alternatives.  
+must define if a requirement is recommended or mandatory, as well as any allowable
+alternatives.
 
 
 === Relationship with external protection profiles

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -26,16 +26,16 @@ trustworthy devices in an ecosystem.
 [title= "Generic security reference model"]
 image::img_ch2_reference-model.png[]
 
-The figure above outlines a generic security reference model and taxonomy. This specification 
+The figure above outlines a generic security reference model and taxonomy. This specification
 is oriented around this reference model. The model is not tied to any particular implementation.
 
 Most systems are built with multiple software components each managing _assets_
 that need to be protected. These components are often sourced from multiple
 different supply chains. The security reference model uses the generic term
-_domain_ to identify an isolated environment, with at least some private 
+_domain_ to identify an isolated environment, with at least some private
 resources and execution state not accessible to at least some other domain(s).
 The figure above shows two examples, one with a single domain, the other with two domains for illustrative purposes but some
-use-cases can require more. The two domains are notionally labelled _hosting domain_ and _confidential domain_ but they have identical properties. _Workloads_ are run in a domain, and are isolated from each other within that domain. Isolation within a domain may be managed by a _runtime environment_ or a _domain security manager_.  Switching between domains may be managed by a _root domain security manager_.  
+use-cases can require more. The two domains are notionally labelled _hosting domain_ and _confidential domain_ but they have identical properties. _Workloads_ are run in a domain, and are isolated from each other within that domain. Isolation within a domain may be managed by a _runtime environment_ or a _domain security manager_.  Switching between domains may be managed by a _root domain security manager_.
 Isolated domains at the software level are typically reflected in isolated domains at the system hardware level, where hardware resouces and _devices_ can be assigned or restricted to specific software domains. For example, device DMA transfers can be restricted to memory assigned to a particular domain. Additional platform services may be required in more complex systems. To illustrate this, _Platform QoS_ is shown in the two domain example.
 
 This specification does not imply or limit the number of domains or the type of use cases a RISC-V system can support. See
@@ -135,7 +135,7 @@ Examples of isolation mechanisms include:
 
 * Privilege based isolation +
 More privileged software is able to access some assets that can enforce security guarantees for less
-privileged software. For instance access to state used to set up virtual memory system is restricted by privilege level. 
+privileged software. For instance access to state used to set up virtual memory system is restricted by privilege level.
 * Physical memory isolation +
 More privileged software controls memory access for less privileged software.
 * Domain isolation +
@@ -146,7 +146,7 @@ lower privileged software in a different domain)
 * Virtualization +
 Virtualization creates and manages _virtual resources_ - compute, memory,
 devices - abstracted from actual physical hardware. A system, or individual
-domains, can be virtualized. This abstraction can be used to restrict a workload to run  
+domains, can be virtualized. This abstraction can be used to restrict a workload to run
 with access to a defined set of resources, isolated from other workloads.
 
 On complex systems the TCB can grow large and become difficult to certify and
@@ -172,10 +172,10 @@ RISC-V has a range of isolation mechanisms available and in development.
 |===
 | Technology
 | Use Case
-| Controlling + 
+| Controlling +
 Privilege +
 level
-| Memory 
+| Memory
 | Granularity
 | Limitations
 
@@ -240,11 +240,11 @@ HS - HS isolation )
 | Third Table Walk to implement smmpt
 
 | IOMPT
-| System Level MPT 
+| System Level MPT
 | M
 | Physical
 | Page or larger
-| 
+|
 
 | CHERI
 | Full Capability based access for memory safety and isolation
@@ -273,7 +273,7 @@ break security guarantees, either directly or indirectly. For example:
 
 * External debug - may allow direct access to confidential data or runtime control
 * Power and timing management - may enable remote fault injection and side channel leakage
-* RAS (_reliability, accessibility, serviceability_) - features such as error correction may mask attacks, out of band management may give privileged access for remote diagnostics, error reporting can leak memory layout or address, stack traces etc. 
+* RAS (_reliability, accessibility, serviceability_) - features such as error correction may mask attacks, out of band management may give privileged access for remote diagnostics, error reporting can leak memory layout or address, stack traces etc.
 
 [#cat_sr_sub_inv]
 [width=100%]
@@ -297,7 +297,7 @@ non-M-mode software.
 NOTE: Fully disabling invasive subsytems, or limiting access in other ways can be an alternative to partitioning by privilige level or domain. +
 When an invasive subsystem cannot be disabled for functional reasons, or runs across all privilege levels, the design must ensure security guarantees are maintained
 using appropriate techniques such as dedicated management networks, hardware-enforced frequency/voltage limits +
-Each invasive subsystem may use different means to ensure security guarantees.  
+Each invasive subsystem may use different means to ensure security guarantees.
 
 ==== Event counters
 
@@ -325,7 +325,7 @@ domain, without consent.
 
 |===
 
-NOTE:  While it's always necessary to prevent lower-privilege software from monitoring higher-privilege software, it may also be necessary to prevent software in one domain from monitoring software in a different domain — even if it operates at the same or lower privilege levels. 
+NOTE:  While it's always necessary to prevent lower-privilege software from monitoring higher-privilege software, it may also be necessary to prevent software in one domain from monitoring software in a different domain — even if it operates at the same or lower privilege levels.
 
 ==== Platform quality of service
 
@@ -361,12 +361,12 @@ domain, without consent.
 ==== Denial of service
 
 The RISC-V security model is primarily concerned with protection of assets, and not with providing service guarantees. However, a given
-use case may require service guarantees that extend to preventing denial of service (DoS) by a malicious workload. For instance, software in a virtual machine must not have the ability to bring down the cloud provider's infrastructure; a power management domain may require the ability to always respond to thermal events etc. Other use cases may not consider DoS in their threat model - for instance where all platform software is considered trustworthy, or where denial of service by user provided software would only achieve denying service to that user.  
+use case may require service guarantees that extend to preventing denial of service (DoS) by a malicious workload. For instance, software in a virtual machine must not have the ability to bring down the cloud provider's infrastructure; a power management domain may require the ability to always respond to thermal events etc. Other use cases may not consider DoS in their threat model - for instance where all platform software is considered trustworthy, or where denial of service by user provided software would only achieve denying service to that user.
 
 In use cases where preventing DoS is considered an objective, Higher privileged software must always be able to enforce its own resource management policy without interference, including scheduling, resource assignment and revocation policies.
 
 Similarly, a hosting domain owning resource allocation and host management across a system normally has to be able to enforce its own policies across domains. Other domains should not be able to deny service to the hosting domain, or to other domains.
- 
+
 
 [#cat_sr_sub_dos]
 [width=100%]
@@ -380,7 +380,7 @@ Similarly, a hosting domain owning resource allocation and host management acros
 privileged software, or other isolated workloads at the same privilege level.
 
 | SR_DOS_002
-| Software in one domain MUST NOT be able to deny service to software in a different domain, 
+| Software in one domain MUST NOT be able to deny service to software in a different domain,
 irrespective of privilege level
 
 |===
@@ -425,13 +425,13 @@ An adversary is able to chain together multiple direct and indirect attacks to
 achieve a goal. For example, using a software interface exploit to affect the call
 stack such that control flow is redirected to the adversary's code.
 
-The threats considered in-scope and the required level of protection will vary depending on use case. For example, a HW RoT would likely have a large set of threats that are considered applicable. Mitigating these threats may require protection against complex or advanced physical attacks. A Software based TEE may limit the threats considered applicable, and therefore the required mitigations. 
+The threats considered in-scope and the required level of protection will vary depending on use case. For example, a HW RoT would likely have a large set of threats that are considered applicable. Mitigating these threats may require protection against complex or advanced physical attacks. A Software based TEE may limit the threats considered applicable, and therefore the required mitigations.
 
 This specification is primarily concerned with ISA level mitigations against logical attacks.
 
 Physical or remote attacks in general need to be addressed at system, protocol or governance level, and can require additional non-ISA mitigations. However, some ISA level mitigations can also help provide some mitigation against physical or remote attacks and this is indicated in the tables below.
 
-Finally, this specification does not attempt to rate attacks by severity, or by adversary skill level. Ratings tend to depend on use case specific threat models and requirements. 
+Finally, this specification does not attempt to rate attacks by severity, or by adversary skill level. Ratings tend to depend on use case specific threat models and requirements.
 
 
 ==== Logical
@@ -553,7 +553,7 @@ a| * Smstateen +
 | Direct or indirect +
 Physical or remote
 | For example, observing radiation, power line patterns, or temperature.
-a| * Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs.  
+a| * Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs.
 * Data Independent Execution Latency (Zkt, Zvkt)
 
 
@@ -562,10 +562,10 @@ a| * Implement power analysis mitigations such as cryptographic masking, constan
 | Direct +
 Logical or physical
 | Using NVDIMMs (susceptible to remanence attack), interposers, or physical probing to read, record, replay or relocate data in physical memory.
-a| * Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding.  
+a| * Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding.
 * Supervisor domain ID, privilege level, or MPT attributes may be used to
 derive separate memory encryption contexts at domain or workload granularity
-* Provide physical tamper resistance, such as an active mesh over critical logic, or case-opening sensors.  
+* Provide physical tamper resistance, such as an active mesh over critical logic, or case-opening sensors.
 
 // * Physical attacks on hardware shielded locations to extract hardware
 // provisioned assets
@@ -578,10 +578,10 @@ Logical or physical
 | Glitching to bypass secure boot +
 Retrieving residual confidential memory after a system reset
 a| * Implement robust power management, and adopt glitch-safe software techniques. +
- 
+
 * Industry best practice should be followed. For example: ensuring un-initialized variables are not used; implementing integrity checking of critical data and hardware provisioned parameters; implementing redundancy in encoding, verification, branching, and critical logic. +
- 
-* Adopt randomization techniques between boot sessions. For example: cryptographic memory protection with at least boot freshness; register randomization. 
+
+* Adopt randomization techniques between boot sessions. For example: cryptographic memory protection with at least boot freshness; register randomization.
 
 * Hardware mitigation such as glitch detection, voltage and clock monitoring
 
@@ -601,7 +601,7 @@ an ecosystem.
 Logical or physical
 | Rowhammer-type software attacks to manipulate nearby memory cells. +
 Fault injection attacks (glitching, laser, electromagnetic, etc.) to extract hardware-provisioned assets, modify the control flow, circumvent countermeasures, etc.
-a| * Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance. 
+a| * Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance.
 * Provide a level of tamper resistance, e.g., through RoT attestation, redundancy during execution, etc.
 * Enforce proper access control for the DVFS configuration.
 * Employ lockstep processors for security-critical devices.
@@ -1017,7 +1017,7 @@ part of an already attested trust contract between a relying party and the
 system.
 |===
 
-NOTE: A system may choose to defer updates to maintain an attested security state. 
+NOTE: A system may choose to defer updates to maintain an attested security state.
 
 A live update changes the attested security state of the affected
 component(s), as well as that of all other components that depend on it. It can
@@ -1091,7 +1091,7 @@ models.
 | SR_ISO_001
 | Isolated software components MUST be supported
 |===
- 
+
 
 An isolated component has private memory and private execution contexts not
 accessible to other components.

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -419,8 +419,8 @@ device-initiated transactions, complementing PMP and SPMP rules.
 | Requirement
 
 | SR_IOP_001
-| A system which supports PMP/Smepmp, or SPMP, MUST implement either IOPMP for device
-access control.
+| A system which supports PMP/Smepmp, or SPMP, MUST implement either IOPMP or
+World for device access control.
 
 | SR_IOP_002
 | IOPMP configurations MUST only be directly accessible to machine mode.
@@ -493,7 +493,46 @@ locations. It complements the MMU.
 
 |===
 
-NOTE: Systems using IOMMU must ensure this cannot be used to bypass physical memory access controls by implementing IOPMP and/or IOMPT
+NOTE: Systems using IOMMU must ensure this cannot be used to bypass physical
+memory access controls by implementing IOPMP, IOMPT or Worlds.
+
+==== Worlds
+
+_This extension is not ratified at the time of writing, but is stable enough to be included_
+
+*See the https://github.com/riscv/riscv-worlds[RISC-V Worlds] specification.*
+
+Worlds defines access context IDs (or world IDs) which allow different access
+policies to be programmed between an agent and a resource in a system. The IDs
+are created and assigned before or at reset/boot time, and are immutable
+afterwards. Any bus transaction stemming from an agent within a world always
+carries its world ID.
+
+[width=100%]
+[%header, cols="5,20"]
+|===
+| ID#
+| Requirement
+
+| SR_WOR_001
+| A system which supports PMP/Smepmp, or SPMP, MUST implement either IOPMP or
+Worlds for device access control.
+
+| SR_WOR_002
+| Worlds configurations MUST only be performed by a trusted entity in the system.
+
+| SR_WOR_003
+| Worlds MUST be used to guarantee that devices assigned to lower privilege
+levels cannot access resources assigned to M-Mode.
+
+| SR_WOR_004
+| Worlds MUST be used to guarantee that devices assigned to a world cannot be
+accessed by other worlds.
+
+NOTE: Depending on the usecase, it is possible to replace IOMPT/IOPMP and
+PMP/ePMP with Worlds.
+
+|===
 
 === Software enforced memory tagging
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -525,8 +525,8 @@ always carries its world ID.
 transaction to enforce isolation of resources.
 
 | SR_WOR_004
-| Immutable software MUST lock the `mwid` CSR before executing mutable software
-(Smwid).
+| M-Mode boot firmware, that configures the hart, MUST lock the mwid CSR at the
+earliest possible boot stage (Smwid).
 
 | SR_WOR_005
 | If a hart supports multiple privilege levels, world IDs MUST be used to

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -502,11 +502,11 @@ _This extension is not ratified at the time of writing, but is stable enough to 
 
 *See the https://github.com/riscv/riscv-worlds[RISC-V Worlds] specification.*
 
-Worlds defines access context IDs (or world IDs) which allow different access
-policies to be programmed between an agent and a resource in a system. The IDs
-are created and assigned before or at reset/boot time, and are immutable
-afterwards. Any bus transaction stemming from an agent within a world always
-carries its world ID.
+Worlds defines execution context IDs (or world IDs) which allow different
+access policies to be programmed between an agent and a resource in a system.
+The IDs are created and assigned before or at reset/boot time, and are
+immutable afterwards. Any bus transaction stemming from an agent within a world
+always carries its world ID.
 
 [width=100%]
 [%header, cols="5,20"]
@@ -515,22 +515,31 @@ carries its world ID.
 | Requirement
 
 | SR_WOR_001
-| A system which supports PMP/Smepmp, or SPMP, MUST implement either IOPMP or
-Worlds for device access control.
+| RISC-V Worlds MUST be used to indicate execution contexts.
 
 | SR_WOR_002
 | Worlds configurations MUST only be performed by a trusted entity in the system.
 
 | SR_WOR_003
-| Worlds MUST be used to guarantee that devices assigned to lower privilege
-levels cannot access resources assigned to M-Mode.
+| If IOPMP is implemented it MUST use the World ID to determine the context of a
+transaction to enforce isolation of resources.
 
 | SR_WOR_004
-| Worlds MUST be used to guarantee that devices assigned to a world cannot be
-accessed by other worlds.
+| Immutable software MUST lock the `mwid` CSR before executing mutable software
+(Smwid).
 
-NOTE: Depending on the usecase, it is possible to replace IOMPT/IOPMP and
-PMP/ePMP with Worlds.
+| SR_WOR_005
+| If a hart supports multiple privilege levels, world IDs MUST be used to
+guarantee that devices assigned to a world ID with a higher privilege level
+cannot be accessed by world IDs from lower privilege levels (Smlwid).
+
+| SR_WOR_006
+| If a hart supports multiple privilege levels, world IDs used by machine-mode
+MUST not be delegated to lower privilege levels (Smlwidlist).
+
+| SR_WOR_007
+| If a hart supports supervisor mode, world IDs used by supervisor-mode MUST
+not be delegated to user-mode (Smwdeleg).
 
 |===
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -494,7 +494,7 @@ locations. It complements the MMU.
 |===
 
 NOTE: Systems using IOMMU must ensure this cannot be used to bypass physical
-memory access controls by implementing IOPMP, IOMPT or Worlds.
+memory access controls by implementing IOPMP or IOMPT.
 
 ==== Worlds
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -6,7 +6,7 @@ This chapter outlines brief descriptions of RISC-V security building blocks
 discussed in this specification, together with general guidelines and links to
 technical specifications. The requirement to use a specific mechanism is
 use case dependent. RISC-V has multiple mechanisms that can be used to achieve the
-same goal, the notes associated with SRs indicate where this is the case. 
+same goal, the notes associated with SRs indicate where this is the case.
 
 See also the reference use cases chapter of this specification for common
 examples of how RISC-V security building blocks can be combined.
@@ -122,7 +122,7 @@ used to mitigate against privilege escalation attacks.
 | If PMP is supported then Smepmp MUST be supported.
 |===
 
-==== SPMP 
+==== SPMP
 
 _This extension is not ratified at the time of writing, but is stable enough to be included_
 
@@ -146,10 +146,10 @@ memory allocations to its workloads.
 | Requirement
 
 | SR_PMP_004
-| SPMP MUST be used to protect S-Mode from lower privilege levels. 
+| SPMP MUST be used to protect S-Mode from lower privilege levels.
 
 | SR_PMP_005
-| SPMP MUST be used to protect U-mode workloads from other U-mode workloads. 
+| SPMP MUST be used to protect U-mode workloads from other U-mode workloads.
 
 | SR_PMP_006
 | SPMP configurations MUST only be directly accessible to machine mode and supervisor mode
@@ -196,7 +196,7 @@ NOTE: Dependent on the use case, it may be recommended or mandatory to use MMU t
 
 NOTE: Dependent on the use case, Trusted Execution Environments may require or recommend the use of MMU to isolate trusted applications from each other. The SPMP and PMP may be an additional or alternative mechanism.
 
-==== Address‑Independent Latency of Faults 
+==== Address‑Independent Latency of Faults
 
 To prevent timing side channels that may infer the address space layout of supervisor memory, user-mode accesses to supervisor-mode memory must raise and exception in constant time. The Svukte extension ensures instruction fetches and explicit memory accesses from U-Mode to S-Mode addresses generate page faults independent of the target address, mitigating this timing attack.
 
@@ -302,7 +302,7 @@ to an lower trust level supervisor domain. The trust levels/policies are specifi
 security system designer.
 
 | SR_SUD_005
-| Resources assigned to an untrusted supervisor domain MUST be accessible to a trusted supervisor domain 
+| Resources assigned to an untrusted supervisor domain MUST be accessible to a trusted supervisor domain
 |===
 
 Supervisor domains allow resource isolation and sharing between domains under the control of M-Mode firmware. Trusted Execution Environments can require asymmetric sharing models, where one trusted domain has X/W/R access to other domain's resources.
@@ -355,8 +355,8 @@ RoT (non M-Mode external debug).
 
 |===
 
-NOTE: Systems with the same ownership between M-Mode and non-M-Mode software may choose to enable external debug for all software or none. 
-Other trust models may require external debug be enabled for non-M-Mode software without affecting M-Mode (recoverable debug). 
+NOTE: Systems with the same ownership between M-Mode and non-M-Mode software may choose to enable external debug for all software or none.
+Other trust models may require external debug be enabled for non-M-Mode software without affecting M-Mode (recoverable debug).
 Where external debug is not enabled, systems may use an S-Mode OS to enable self-hosted debug for a user application without affecting other applications or S-Mode itself.
 
 [width=100%]
@@ -393,8 +393,8 @@ affected component, MUST be subject to an application specific governance proces
 
 |===
 
-NOTE: Enabling debug after measurement ensures the system remains attestable but can affect the 
-confidentiality and trustworthiness of the affected components, and must be subject to an attested policy  
+NOTE: Enabling debug after measurement ensures the system remains attestable but can affect the
+confidentiality and trustworthiness of the affected components, and must be subject to an attested policy
 
 *See chapters 7 and 9 of the https://github.com/riscv/riscv-isa-manual/releases/latest[Privileged
 ISA] specification on performance counters.*
@@ -576,7 +576,7 @@ extensions
 extensions
 
 | SR_CPT_003
-| The entropy source ISA extension MUST be supported 
+| The entropy source ISA extension MUST be supported
 
 |===
 
@@ -589,7 +589,7 @@ In the context of this document, _architectural metadata_ refers to any data tha
 
 Examples (not exhaustive) where architectural metadata may be required in current or future RISC-V architecture include:  MTT, memory tagging, and CHERI.
 
-Architectural metadata storage is implementation defined, but the following rules should be considered by any implementation. 
+Architectural metadata storage is implementation defined, but the following rules should be considered by any implementation.
 
 [width=100%]
 [%header, cols="5,20"]
@@ -608,7 +608,7 @@ Architectural metadata storage is implementation defined, but the following rule
 
 |===
 
-See xref:chapter2.adoc#_adversarial_model[adversarial model] 
+See xref:chapter2.adoc#_adversarial_model[adversarial model]
 
 For example, architectural metadata storage may be implemented in on-chip memory, or in cryptographically protected external DDR.
 
@@ -647,7 +647,7 @@ Depending on the use case, architectural metadata may be visible to or managed b
 
 NOTE: Architectural metadata needs to be protected against both unauthorized access (read or modify), boot attacks, relocation attacks, and errors (accidental or malicious).
 
-NOTE: On systems where architectural metadata is stored in external memory, and external memory attacks are in scope (for example, directly accessible or replaceable external memory), then cryptographic protection with replay protection or temporal freshness is strongly recommended. 
+NOTE: On systems where architectural metadata is stored in external memory, and external memory attacks are in scope (for example, directly accessible or replaceable external memory), then cryptographic protection with replay protection or temporal freshness is strongly recommended.
 
 [width=100%]
 [%header, cols="5,20"]
@@ -663,7 +663,7 @@ NOTE: On systems where architectural metadata is stored in external memory, and 
 NOTE: In general, protection against indirect attacks is a system implementation problem not specific to architectural metadata storage. For example, systems supporting speculative execution should also implement appropriate mitigations against speculation based attacks. Any such mitigations should also be applied to the implementation of architectural metadata storage.
 
 
-=== Extensions in development 
+=== Extensions in development
 
 
 


### PR DESCRIPTION
Fixes #121 

Add Worlds section. Replicate most of the IDs from PMP and IOPMP (and their variants) to worlds. Mention worlds where applicable.

@andrewdellow please double check the IDs. I know that ARC's feedback was to use IDs even when they replicate or contradict other IDs, but I want to be certain this is fine.