### PR TITLE
typo tidy up for release

### DIFF
--- a/specification/src/chapter1.adoc
+++ b/specification/src/chapter1.adoc
@@ -25,13 +25,13 @@ The set of examples may be extended over time as required.
 RISC-V is not intending to create a security certification program.
 This specification is provided as guidance for developing secure
 RISC-V systems which are certifiable within existing third party security
-certification programmes.
+certification programs.
 
 This specification does not define any new RISC-V ISA or non-ISA extensions.
 Instead it refers to the existing RISC-V ISA and extensions, as well as commonly
 used non-RVI architecture agnostic security features and processes. It aims to show
 how those can be combined, in commonly used examples, to create systems which
-are certifiable within commonly used existing security certification programmes.
+are certifiable within commonly used existing security certification programs.
 
 The examples are not definitions of formal Protection Profilesfootnote:[
 https://csrc.nist.gov/glossary/term/protection_profile]. Formal protection

--- a/specification/src/chapter1.adoc
+++ b/specification/src/chapter1.adoc
@@ -37,7 +37,7 @@ The examples are not definitions of formal Protection Profilesfootnote:[
 https://csrc.nist.gov/glossary/term/protection_profile]. Formal protection
 profiles are typically provided by third party certification bodies for
 different ecosystems. The guidelines provided within the examples in this
-specification are intended to help readers adapt RISC-V security features to
+specification are intended to help readers adopt RISC-V security features to
 meet security requirements of commonly used third party protection profiles.
 Mapping documentation or protection profiles may also directly reference this
 document.

--- a/specification/src/chapter1.adoc
+++ b/specification/src/chapter1.adoc
@@ -139,7 +139,7 @@ referenced by this specification:
 | Description
 
 | Global Platforms (GP)
-| Trusted execution environments(TEE) and trusted firmware for mobile,
+| Trusted execution environments (TEE) and trusted firmware for mobile,
 connected clients, and IoT. +
 Secure element (SE) for tamper resistant storage of and operations on
 cryptographic secrets. +

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -474,10 +474,10 @@ https://meltdownattack.com/[Spectre and meltdown papers] +
 https://www.intel.com/content/www/us/en/developer/topic-technology/software-security-guidance/processors-affected-consolidated-product-cpu-model.html[Intel
 security guidance] +
 https://developer.arm.com/documentation/#cf-navigationhierarchiesproducts=Arm%20Security%20Center,Speculative%20Processor%20Vulnerability[Arm speculative
-vulnerability]
-| CBQRI and Ssqosid may help isolate cache entries. +
+vulnerability] +
+CBQRI and Ssqosid may help isolate cache entries. +
 Zicfilp and Zicfiss can mitigate against ROP/COP/JOP, limiting some compound attacks.
-Fence.time, Speculation barriers or similar future extensions, may at least partially mitigate against In-domain attacks (such as Spectre V1 , V4).
+| Fence.time, Speculation barriers or similar future extensions, may at least partially mitigate against In-domain attacks (such as Spectre V1 , V4).
 
 | T_LGC_003
 | Interface abuse
@@ -537,6 +537,10 @@ Ssstateen
 |
 
 |===
+
+NNOTE: Entropy provided through a RISC-V Zkr-compliant entropy source can be used to improve the effectiveness of several attack mitigations. 
+Examples include address-space randomization, timing randomization, data masking, and noise-injection techniques. 
+These mechanisms rely on high-quality, unpredictable random values to hinder attacker observation and prediction.
 
 ==== Physical and remote
 

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -453,7 +453,7 @@ Finally, this specification does not attempt to rate attacks by severity, or by 
 | Direct +
 Logical
 | Unauthorized direct access to resources in normal operation.
-a| RISC-V privilege levels +
+| RISC-V privilege levels +
 RISC-V isolation (for example: PMP/ePMP, SPMP, MTT, supervisor domains) +
 RISC-V hardware-enforced virtualization (H extension, MMU, IOMMU) +
 | Capability based architecture, such as CHERI, RISC-V Worlds +
@@ -464,7 +464,7 @@ Architectural sandboxing, such as Hardware Fault Isolation (HFI).
 | Chained +
 Logical
 | Attacks on speculative execution implementations.
-a| Domain-bypass and Cross-domain attacks can be mitigated at a microarchitectural level by isolating predictive microarchitectural resources. Micro-architecture for RISC-V systems is implementation
+| Domain-bypass and Cross-domain attacks can be mitigated at a microarchitectural level by isolating predictive microarchitectural resources. Micro-architecture for RISC-V systems is implementation
 specific, and must consider such vulnerabilities. +
  +
 This is an evolving area of research. +
@@ -485,7 +485,7 @@ Fence.time, Speculation barriers or similar future extensions, may at least part
 Logical
 | Abusing interfaces across privilege or isolation boundaries, for example to
 elevate privilege or to gain unauthorized access to resources.
-a| RISC-V privilege levels +
+| RISC-V privilege levels +
 RISC-V isolation
 | High assurance cryptography can isolate key material from SW
 
@@ -495,7 +495,7 @@ RISC-V isolation
 Logical
 | For example, timing processes across privilege or isolation boundaries to
 derive information about confidential assets.
-a| Data-independent timing instructions (Zkt, Zkvt) +
+| Data-independent timing instructions (Zkt, Zkvt) +
 Performance counters restricted by privilege and isolation boundaries
 (sscofpmf, smcntrpmf)
 |
@@ -506,7 +506,7 @@ Performance counters restricted by privilege and isolation boundaries
 Logical
 | Unauthorized manipulation of call stacks and jump targets to redirect a
 control flow to code controlled by an attacker.
-a| Shadow stacks (Zicfiss) +
+| Shadow stacks (Zicfiss) +
 Landing pads (Zicfilp) +
 Pointer Masking 
 | Capability based architecture, such as CHERI, +
@@ -516,7 +516,7 @@ Pointer Masking
 | Memory safety
 | Logical
 | Unauthorized access to resources within an isolated component. For example, pointer or allocation errors (temporal memory safety), or buffer overflows (spatial memory safety).
-a| RISC-V pointer masking (Sspm, Supm) +
+| RISC-V pointer masking (Sspm, Supm) +
 Shadow stacks (Zicfiss) +
 Landing pads (Zicfilp) +
 Memory Tagging
@@ -532,8 +532,8 @@ Capability based architecture, such as CHERI.
 | Architectural Covert Channel
 | Logical
 | Execution environment is unaware of, or doesn't swap/sanitize CSRs on context switch, creating covert communication channel between user threads or guest OSs
-a| * Smstateen +
-* Ssstateen
+| Smstateen +
+Ssstateen
 |
 
 |===
@@ -555,7 +555,7 @@ a| * Smstateen +
 | Direct or indirect +
 Physical or remote
 | For example, observing radiation, power line patterns, or temperature.
-a<|  Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs. +
+|  Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs. +
 
 Implement Data Independent Execution Latency (Zkt, Zvkt) +
 Utilise entropy source in randomisation (Zkr)
@@ -566,7 +566,7 @@ Utilise entropy source in randomisation (Zkr)
 | Direct +
 Logical or physical
 | Using NVDIMMs (susceptible to remanence attack), interposers, or physical probing to read, record, replay or relocate data in physical memory.
-a<| Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding. +
+| Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding. +
 Supervisor domain ID, privilege level, or MPT attributes may be used to
 derive separate memory encryption contexts at domain or workload granularity +
 
@@ -582,7 +582,8 @@ Provide physical tamper resistance, such as an active mesh over critical logic, 
 Logical or physical
 | Glitching to bypass secure boot +
 Retrieving residual confidential memory after a system reset
-a<| Implement robust power management, and adopt glitch-safe software techniques. +
+
+| Implement robust power management, and adopt glitch-safe software techniques. +
 
 Industry best practice should be followed. For example: ensuring un-initialized variables are not used; implementing integrity checking of critical data and hardware provisioned parameters; implementing redundancy in encoding, verification, branching, and critical logic. +
 
@@ -597,7 +598,7 @@ Hardware mitigation such as glitch detection, voltage and clock monitoring +
 supply chains and signing processes, hardware supply chains, attestation
 processes, development processes (for example, unfused development hardware or
 debug authorizations)
-a| Deploy appropriate governance, accreditation, and certification processes for
+| Deploy appropriate governance, accreditation, and certification processes for
 an ecosystem.
 
 | T_PHY_005
@@ -606,7 +607,8 @@ an ecosystem.
 Logical or physical
 | Rowhammer-type software attacks to manipulate nearby memory cells. +
 Fault injection attacks (glitching, laser, electromagnetic, etc.) to extract hardware-provisioned assets, modify the control flow, circumvent countermeasures, etc.
-a<| Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance. +
+
+| Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance. +
 
 Provide a level of tamper resistance, e.g., through RoT attestation, redundancy during execution, etc. +
 

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -169,7 +169,7 @@ RISC-V has a range of isolation mechanisms available and in development.
 
 [#cat_sr_sub_ism]
 [width=100%]
-[%header, cols="10,20,8,6,8,9"]
+[%header, cols="10,20,8,5,8,10"]
 |===
 | Technology
 | Use Case
@@ -453,9 +453,9 @@ Finally, this specification does not attempt to rate attacks by severity, or by 
 | Direct +
 Logical
 | Unauthorized direct access to resources in normal operation.
-a| * RISC-V privilege levels
-* RISC-V isolation (for example: PMP/ePMP, SPMP, MTT, supervisor domains)
-* RISC-V hardware-enforced virtualization (H extension, MMU, IOMMU)
+a| RISC-V privilege levels +
+RISC-V isolation (for example: PMP/ePMP, SPMP, MTT, supervisor domains) +
+RISC-V hardware-enforced virtualization (H extension, MMU, IOMMU) +
 | Capability based architecture, such as CHERI, RISC-V Worlds +
 Architectural sandboxing, such as Hardware Fault Isolation (HFI).
 
@@ -464,10 +464,10 @@ Architectural sandboxing, such as Hardware Fault Isolation (HFI).
 | Chained +
 Logical
 | Attacks on speculative execution implementations.
-a| * Domain-bypass and Cross-domain attacks can be mitigated at a microarchitectural level by isolating predictive microarchitectural resources. Micro-architecture for RISC-V systems is implementation
+a| Domain-bypass and Cross-domain attacks can be mitigated at a microarchitectural level by isolating predictive microarchitectural resources. Micro-architecture for RISC-V systems is implementation
 specific, and must consider such vulnerabilities. +
  +
-* This is an evolving area of research. +
+This is an evolving area of research. +
  +
  For example: +
 https://meltdownattack.com/[Spectre and meltdown papers] +
@@ -485,8 +485,8 @@ Fence.time, Speculation barriers or similar future extensions, may at least part
 Logical
 | Abusing interfaces across privilege or isolation boundaries, for example to
 elevate privilege or to gain unauthorized access to resources.
-a| * RISC-V privilege levels
-* RISC-V isolation
+a| RISC-V privilege levels +
+RISC-V isolation
 | High assurance cryptography can isolate key material from SW
 
 | T_LGC_004
@@ -495,8 +495,8 @@ a| * RISC-V privilege levels
 Logical
 | For example, timing processes across privilege or isolation boundaries to
 derive information about confidential assets.
-a| * Data-independent timing instructions (Zkt, Zkvt)
-* Performance counters restricted by privilege and isolation boundaries
+a| Data-independent timing instructions (Zkt, Zkvt) +
+Performance counters restricted by privilege and isolation boundaries
 (sscofpmf, smcntrpmf)
 |
 
@@ -506,9 +506,9 @@ a| * Data-independent timing instructions (Zkt, Zkvt)
 Logical
 | Unauthorized manipulation of call stacks and jump targets to redirect a
 control flow to code controlled by an attacker.
-a| * Shadow stacks (Zicfiss)
-* Landing pads (Zicfilp)
-* Pointer Masking 
+a| Shadow stacks (Zicfiss) +
+Landing pads (Zicfilp) +
+Pointer Masking 
 | Capability based architecture, such as CHERI, +
   Memory Tagging
 
@@ -516,9 +516,9 @@ a| * Shadow stacks (Zicfiss)
 | Memory safety
 | Logical
 | Unauthorized access to resources within an isolated component. For example, pointer or allocation errors (temporal memory safety), or buffer overflows (spatial memory safety).
-a| * RISC-V pointer masking (Sspm, Supm) +
-* Shadow stacks (Zicfiss) +
-* Landing pads (Zicfilp) +
+a| RISC-V pointer masking (Sspm, Supm) +
+Shadow stacks (Zicfiss) +
+Landing pads (Zicfilp) +
 Memory Tagging
  +
 Memory safe programming +

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -248,7 +248,7 @@ HS - HS isolation )
 |
 
 | CHERI
-| Full Capability based access for memory safety and isolation
+| Full Capability-based access control for memory safety and isolation
 | M S U
 | Both
 | Fine Grained
@@ -538,7 +538,7 @@ Ssstateen
 
 |===
 
-NOTE: Entropy provided through a RISC-V Zkr-compliant entropy source can be used to improve the effectiveness of several attack mitigations. 
+NOTE: Entropy obtained through a RISC-V Zkr-compliant entropy source can be used to improve the effectiveness of several attack mitigations. 
 Examples include address-space randomization, timing randomization, data masking, and noise-injection techniques. 
 These mechanisms rely on high-quality, unpredictable random values to hinder attacker observation and prediction.
 
@@ -620,7 +620,7 @@ Enforce proper access control for the DVFS configuration. +
 
 Employ lockstep processors for security-critical devices. +
 
-Employ physical sensors to detect attack
+Employ physical sensors to detect attacks
 
 |===
 
@@ -753,7 +753,7 @@ identifier.
 | Requirement
 
 | SR_LFC_002
-| Hardware provisioned assets MUST only be accessible while the system is in
+| After completion of security provisioning, Hardware provisioned assets MUST only be accessible while the system is in
 secured state, or a recoverable debug state (with the recoverable debug state in
 attestation evidence).
 
@@ -993,7 +993,7 @@ subsystems can also include immutable software to meet specific security
 certification requirements.
 
 System updates are typically layered so that updates can target only parts of a
-system and not a whole system. The properties discussed below still apply to
+system and not only the whole system. The properties discussed below still apply to
 any system update.
 
 [width=100%]

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -274,7 +274,7 @@ break security guarantees, either directly or indirectly. For example:
 
 * External debug - may allow direct access to confidential data or runtime control
 * Power and timing management - may enable remote fault injection and side channel leakage
-* RAS (_reliability, accessibility, serviceability_) - features such as error correction may mask attacks, out of band management may give privileged access for remote diagnostics, error reporting can leak memory layout or address, stack traces etc.
+* RAS (_reliability, availability, serviceability_) - features such as error correction may mask attacks, out of band management may give privileged access for remote diagnostics, error reporting can leak memory layout or address, stack traces etc.
 
 [#cat_sr_sub_inv]
 [width=100%]
@@ -806,8 +806,7 @@ an isolated application security service.
 | Requirement
 
 | SR_ATT_001
-| A confidential service, and all software and hardware components it depends
-on, MUST be attestable.
+| A confidential service, and all software and hardware components on which it depends, MUST be attestable.
 |===
 
 Attestation allows a remote relying party to determine the trustworthiness of a

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -260,7 +260,7 @@ HS - HS isolation )
 
 Isolation policy needs to extend to device assignment:
 
-* Physical memory access control for device initiated transactions - to allow only authorised access to a memory region assigned to a device
+* Physical memory access control for device initiated transactions - to allow only authorized access to a memory region assigned to a device
 * Virtual memory translation for virtualized device transactions - to prevent one domain from accessing another's memory via device or memory translation misconfiguration
 * Interrupt management across privilege and domain boundaries - to ensure interrupts are delivered only to the correct domain
 

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -31,9 +31,8 @@ is oriented around this reference model. The model is not tied to any particular
 
 Most systems are built with multiple software components each managing _assets_
 that need to be protected. These components are often sourced from multiple
-different supply chains. The security reference model uses the generic term
-_domain_ to identify an isolated environment, with at least some private
-resources and execution state not accessible to at least some other domain(s).
+different supply chains. The security reference model uses the generic term domain to identify a logical security 
+boundary containing execution state and resources that are inaccessible to at least some other domain(s) 
 The figure above shows two examples, one with a single domain, the other with two domains for illustrative purposes but some
 use cases can require more. The two domains are notionally labelled _hosting domain_ and _confidential domain_ but they have identical properties. _Workloads_ are run in a domain, and are isolated from each other within that domain. Isolation within a domain may be managed by a _runtime environment_ or a _domain security manager_.  Switching between domains may be managed by a _root domain security manager_.  
 Isolated domains at the software level are typically reflected in isolated domains at the system hardware level, where hardware resources and _devices_ can be assigned or restricted to specific software domains. For example, device DMA transfers can be restricted to memory assigned to a particular domain. Additional platform services may be required in more complex systems. To illustrate this, _Platform QoS_ is shown in the two domain example.
@@ -440,7 +439,7 @@ Finally, this specification does not attempt to rate attacks by severity, or by 
 
 [#cat_sr_sub_lgc]
 [width=100%]
-[%header, cols="7,6,5,10,15,15"]
+[%header, cols="<8,<6,<5,<10,<15,<15"]
 |===
 | ID#
 | Threat
@@ -543,7 +542,7 @@ a| * Smstateen +
 
 [#cat_sr_sub_phy]
 [width=100%]
-[%header, cols="7,8,10,15,15"]
+[%header, cols="<7,<8,<10,<15,<15"]
 |===
 | ID#
 | Threat

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -730,7 +730,7 @@ Additional specific provisioning stages can take place in this
 state - for example network onboarding and device activation, App/Device
 attestation or user identity management. This is out of scope of this
 specification.
-* Recoverable debug - part of the system is in a revealing debug state +
+* Recoverable debug - part of the system is in a revealing debug state. +
 At least the RoT is not compromised and hardware provisioned secrets remain
 protected. +
 This state is both attestable and recoverable. For example, revealing debug is
@@ -944,7 +944,7 @@ Verification ensures the system has loaded authorized software.
 | Requirement
 
 | SR_MSM_003
-| A system MUST only use authorizations from trusted authority.
+| A system MUST only use authorizations from a trusted authority.
 |===
 
 * Direct verification requires a signed image authorization from a trusted

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -538,7 +538,7 @@ Ssstateen
 
 |===
 
-NNOTE: Entropy provided through a RISC-V Zkr-compliant entropy source can be used to improve the effectiveness of several attack mitigations. 
+NOTE: Entropy provided through a RISC-V Zkr-compliant entropy source can be used to improve the effectiveness of several attack mitigations. 
 Examples include address-space randomization, timing randomization, data masking, and noise-injection techniques. 
 These mechanisms rely on high-quality, unpredictable random values to hinder attacker observation and prediction.
 

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -71,7 +71,8 @@ The following are examples of software components that can be a part of some fun
 
 ==== Root of trust
 
-A _root of trust (RoT)_ is the foundation on which all secure operations of a system depend. A RoT is typically a combination of a minimal amount of hardware and software that has to be implicitly trusted by all system components.
+A _root of trust (RoT)_ is the foundation on which all secure operations of a system depend. A RoT is typically a combination of a minimal amount of hardware 
+and software that has to be implicitly trusted by all other non-RoT HW and SW in a system.
 
 A RoT supports fundamental security services, for example:
 
@@ -79,6 +80,7 @@ A RoT supports fundamental security services, for example:
 * Security life cycle management
 * Key derivations and sealing (sealing is defined in a later section)
 * Security provisioning
+* Debug authorisation
 
 Depending on use case and ecosystem requirements, a RISC-V RoT can be:
 
@@ -197,8 +199,8 @@ level
 
 | RISC-V Worlds
 | Hardware World Identifiers for System level isolation
-| M, S
-| Physical, PMP, SPMP based
+| HW RoT, M, S
+| Physical
 | Fine Grained
 | Static boot configuration
 
@@ -475,7 +477,7 @@ security guidance] +
 https://developer.arm.com/documentation/#cf-navigationhierarchiesproducts=Arm%20Security%20Center,Speculative%20Processor%20Vulnerability[Arm speculative
 vulnerability]
 | CBQRI and Ssqosid may help isolate cache entries. +
-Zicflip and Zicfiss can mitigate against ROP/COP/JOP, limiting some compound attacks.
+Zicfilp and Zicfiss can mitigate against ROP/COP/JOP, limiting some compound attacks.
 Fence.time, Speculation barriers or similar future extensions, may at least partially mitigate against In-domain attacks (such as Spectre V1 , V4).
 
 | T_LGC_003
@@ -507,6 +509,7 @@ Logical
 control flow to code controlled by an attacker.
 a| * Shadow stacks (Zicfiss)
 * Landing pads (Zicfilp)
+* Pointer Masking 
 | Capability based architecture, such as CHERI, +
   Memory Tagging
 
@@ -553,9 +556,10 @@ a| * Smstateen +
 | Direct or indirect +
 Physical or remote
 | For example, observing radiation, power line patterns, or temperature.
-a|  Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs. +
+a<|  Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs. +
 
-Implement Data Independent Execution Latency (Zkt, Zvkt)
+Implement Data Independent Execution Latency (Zkt, Zvkt) +
+Utilise entropy source in randomisation (Zkr)
 
 
 | T_PHY_002
@@ -563,7 +567,7 @@ Implement Data Independent Execution Latency (Zkt, Zvkt)
 | Direct +
 Logical or physical
 | Using NVDIMMs (susceptible to remanence attack), interposers, or physical probing to read, record, replay or relocate data in physical memory.
-a| Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding. +
+a<| Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding. +
 Supervisor domain ID, privilege level, or MPT attributes may be used to
 derive separate memory encryption contexts at domain or workload granularity +
 
@@ -579,7 +583,7 @@ Provide physical tamper resistance, such as an active mesh over critical logic, 
 Logical or physical
 | Glitching to bypass secure boot +
 Retrieving residual confidential memory after a system reset
-a| Implement robust power management, and adopt glitch-safe software techniques. +
+a<| Implement robust power management, and adopt glitch-safe software techniques. +
 
 Industry best practice should be followed. For example: ensuring un-initialized variables are not used; implementing integrity checking of critical data and hardware provisioned parameters; implementing redundancy in encoding, verification, branching, and critical logic. +
 
@@ -603,7 +607,7 @@ an ecosystem.
 Logical or physical
 | Rowhammer-type software attacks to manipulate nearby memory cells. +
 Fault injection attacks (glitching, laser, electromagnetic, etc.) to extract hardware-provisioned assets, modify the control flow, circumvent countermeasures, etc.
-a| Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance. +
+a<| Implement robust memory error detection, cryptographic memory protection, or physical tamper resistance. +
 
 Provide a level of tamper resistance, e.g., through RoT attestation, redundancy during execution, etc. +
 
@@ -745,7 +749,7 @@ identifier.
 
 | SR_LFC_002
 | Hardware provisioned assets MUST only be accessible while the system is in
-secured state, or a recoverable debug state.(with the recoverable debug state in
+secured state, or a recoverable debug state (with the recoverable debug state in
 attestation evidence).
 
 | SR_LFC_003

--- a/specification/src/chapter2.adoc
+++ b/specification/src/chapter2.adoc
@@ -34,7 +34,7 @@ that need to be protected. These components are often sourced from multiple
 different supply chains. The security reference model uses the generic term domain to identify a logical security 
 boundary containing execution state and resources that are inaccessible to at least some other domain(s) 
 The figure above shows two examples, one with a single domain, the other with two domains for illustrative purposes but some
-use cases can require more. The two domains are notionally labelled _hosting domain_ and _confidential domain_ but they have identical properties. _Workloads_ are run in a domain, and are isolated from each other within that domain. Isolation within a domain may be managed by a _runtime environment_ or a _domain security manager_.  Switching between domains may be managed by a _root domain security manager_.  
+use cases can require more. The two domains are notionally labelled _hosting domain_ and _confidential domain_ but they have identical properties. _Workloads_ are run in a domain, and are isolated from each other within that domain. Isolation within a domain may be managed by a _runtime environment_ or a _domain security manager_.  Switching between domains may be managed by a _Root domain security manager_.  
 Isolated domains at the software level are typically reflected in isolated domains at the system hardware level, where hardware resources and _devices_ can be assigned or restricted to specific software domains. For example, device DMA transfers can be restricted to memory assigned to a particular domain. Additional platform services may be required in more complex systems. To illustrate this, _Platform QoS_ is shown in the two domain example.
 
 This specification does not imply or limit the number of domains or the type of use cases a RISC-V system can support. See
@@ -142,7 +142,7 @@ More privileged software controls memory access for less privileged software.
 * Domain isolation +
 Software in one domain cannot access or modify resources assigned to a different
 domain (without consent), regardless of privilege level. +
-(Higher privileged software in one domain cannot access resources assigned to a
+(Higher privileged software in one domain cannot access resources assigned to
 lower privileged software in a different domain)
 * Virtualization +
 Virtualization creates and manages _virtual resources_ - compute, memory,
@@ -558,7 +558,7 @@ These mechanisms rely on high-quality, unpredictable random values to hinder att
 | Analysis of physical leakage
 | Direct or indirect +
 Physical or remote
-| For example, observing radiation, power line patterns, or temperature.
+| For example, observing electromagnetic emissions, power consumption patterns, or temperature variations.
 |  Implement power analysis mitigations such as cryptographic masking, constant time code, noise injection, timing decorrelation/randomisation, constant power logic designs. +
 
 Implement Data Independent Execution Latency (Zkt, Zvkt) +
@@ -571,7 +571,7 @@ Utilise entropy source in randomisation (Zkr)
 Logical or physical
 | Using NVDIMMs (susceptible to remanence attack), interposers, or physical probing to read, record, replay or relocate data in physical memory.
 | Implement cryptographic memory protection to provide confidentiality and authentication with temporal and spatial binding. +
-Supervisor domain ID, privilege level, or MPT attributes may be used to
+Supervisor Domain ID, privilege level, or MPT attributes may be used to
 derive separate memory encryption contexts at domain or workload granularity +
 
 Provide physical tamper resistance, such as an active mesh over critical logic, or case-opening sensors.
@@ -687,8 +687,8 @@ provisioned assets.
 image::img_ch2_security-lifecycle.png[]
 
 [#security-lifecycle]
-A security life cycle reflects the trustworthiness of a system during its
-lifetime and reflects the life cycle state of hardware provisioned assets.
+A security life cycle reflects both the trustworthiness of a system during its
+lifetime and the life cycle state of hardware provisioned assets.
 
 It can be extended as indicated below to cover additional security provisioning
 steps such as device onboarding, device activation, user management, and RMA (Return Merchandise Authorization)
@@ -753,7 +753,7 @@ identifier.
 | Requirement
 
 | SR_LFC_002
-| After completion of security provisioning, Hardware provisioned assets MUST only be accessible while the system is in
+| After completion of security provisioning, hardware provisioned assets MUST only be accessible while the system is in
 secured state, or a recoverable debug state (with the recoverable debug state in
 attestation evidence).
 
@@ -882,7 +882,9 @@ software.
 Two complementary processes can be used to authorize software:
 
 * Measurement +
-In the context of this document, a measurement is a record of a present state of the system, which can be used by a remote party to verify the security state of the system. It is typically a cryptographic fingerprint, such as a running hash of memory combined with security lifecycle state and other attributes. Although depending on use case other kinds of measurements can be used.
+In the context of this document, a measurement is a record of a present state of the system, which can be used by a remote party to verify the security state of the system. 
+It is typically a cryptographic fingerprint, such as a running hash of memory combined with security life cycle state and other attributes. 
+Although depending on use case other kinds of measurements can be used.
 * Verification +
 Verification is a process of establishing that a measurement is correct
 (expected).

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -37,7 +37,7 @@ software.
 ISA] specification.*
 
 The Hypervisor extension supports standard supervisor level hypervisors. It extends
-S-Mode into Hypervisor-extended supervisor mode (HS-Mode), and a virtual supervisor
+S-Mode into hypervisor-extended supervisor mode (HS-Mode), and a virtual supervisor
 mode (VS-Mode) for guests. It also extends U-Mode into standard user mode (U-Mode) and
 virtual user mode (VU-Mode).
 
@@ -525,7 +525,7 @@ Worlds defines execution context IDs (or World IDs) which allow different
 access policies to be programmed between an agent and a resource in a system.
 The IDs are created and assigned before or at reset/boot time, and are
 immutable afterwards. Any bus transaction stemming from an agent within a World
-always carries its World ID.
+always carries its World ID (WID).
 
 [width=100%]
 [%header, cols="5,20"]

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -709,7 +709,7 @@ For example, architectural metadata storage may be implemented in on-chip memory
 | Requirement
 
 | SR_AMS_004
-| Architectural metadata MUST be isolated by privilege level, and within supervisor domain boundaries
+| Architectural metadata MUST be isolation by execution context/domain and within domain boundaries
 
 |===
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -604,14 +604,6 @@ RISC-V provides two defenses:
 * Shadow stacks (Zicfiss) - protect return addresses on call stacks
 * Labeled Landing pads (Zicfilp) - protect target addresses if indirect jumps
 
-NOTE: NOP-sled and code-injection attacks increase the reliability of control-flow 
-hijacking by allowing redirected execution to land within a broad region of benign 
-instructions that ultimately lead execution to an attacker-controlled payload. 
-RISC-V HINT instructions, as well as other instructions with minimal architecturally 
-visible effects, may be incorporated into NOP-sled-style sequences by an attacker. 
-Detection of such sequences, including those constructed from ISA-defined NOP, HINT, 
-or other NOP-equivalent instruction encodings, is the responsibility of NOP-sled 
-detection software and security tools.
 
 [width=100%]
 [%header, cols="5,20"]
@@ -627,6 +619,15 @@ detection software and security tools.
 branches
 
 |===
+
+NOTE: NOP-sled and code-injection attacks increase the reliability of control-flow 
+hijacking by allowing redirected execution to land within a broad region of benign 
+instructions that ultimately lead execution to an attacker-controlled payload. 
+RISC-V HINT instructions, as well as other instructions with minimal architecturally 
+visible effects, may be incorporated into NOP-sled-style sequences by an attacker. 
+Detection of such sequences, including those constructed from ISA-defined NOP, HINT, 
+or other NOP-equivalent instruction encodings, is the responsibility of NOP-sled 
+detection software and security tools.
 
 === Cryptography
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -215,7 +215,7 @@ NOTE: Dependent on the use case, Trusted Execution Environments may require or r
 
 _This extension is not ratified at the time of writing, but is stable enough to be included_
 
-To prevent timing side channels that may infer the address space layout of supervisor memory, U-Mode accesses to S-Mode memory must raise an exception in constant time. The Svukte extension ensures instruction fetches and explicit memory accesses from U-Mode to S-Mode addresses generate page faults independent of the target address, mitigating this timing attack.
+To prevent timing side channels that may infer the address space layout of supervisor memory, U-Mode accesses to S-Mode memory should raise an exception in constant time. The Svukte extension ensures instruction fetches and explicit memory accesses from U-Mode to S-Mode addresses generate page faults independent of the target address, mitigating this timing attack.
 
 [#cat_sr_sub_KTE]
 [width=100%]
@@ -250,7 +250,7 @@ the SDID, the mmpt CSR may specify a root PPN for a _Memory Protection Table (MP
 The MPT is a memory structure managed by M-Mode that is used to manage physical memory permissions across supervisor domains.
 It is designed to enable page-based dynamic memory management across supervisor
 domain boundaries.
-responsible for resource management.
+
 
 [#cat_sr_sub_mtt]
 [width=100%]
@@ -714,7 +714,8 @@ For example, architectural metadata storage may be implemented in on-chip memory
 
 |===
 
-Depending on the use case, architectural metadata may be visible to or managed by, for example, a supervisor level kernel or hypervisor, a kernel or a hypervisor within a supervisor domain, or by a M-Mode monitor. But it should be considered private within an isolation boundary and not accessible or guessable by lower privilege levels, or by code in a different supervisor domain.
+Depending on the use case, architectural metadata may be visible to or managed by, for example, a supervisor level kernel or hypervisor, a kernel or a hypervisor within a supervisor domain, or by a M-Mode monitor. 
+But it should be considered private within an isolation boundary and not accessible to, or guessable by lower privilege levels, or by code in a different supervisor domain.
 
 [width=100%]
 [%header, cols="5,20"]

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -197,11 +197,11 @@ translation)
 
 | SR_ATP_001
 | If the Sv extension is supported then 1st-stage page tables MUST be used to protect
-the S-Mode Supervisor domain from accesses made by U-Mode.
+the S-Mode supervisor domain from accesses made by U-Mode.
 
 | SR_ATP_002
 | If the H extension is supported 1st-stage and/or G-stage page tables MUST be used to protect
-Supervisor domain H/S-Mode from lower privilege levels.
+supervisor domain H/S-Mode from lower privilege levels.
 
 | SR_ATP_003
 | Address translation and protection MUST be used to protect resources assigned to one workload from other workloads
@@ -215,7 +215,7 @@ NOTE: Dependent on the use case, Trusted Execution Environments may require or r
 
 _This extension is not ratified at the time of writing, but is stable enough to be included_
 
-To prevent timing side channels that may infer the address space layout of supervisor memory, U-Mode accesses to S-Mode memory should raise an exception in constant time. The Svukte extension ensures instruction fetches and explicit memory accesses from U-Mode to S-Mode addresses generate page faults independent of the target address, mitigating this timing attack.
+To prevent timing side-channels that may infer the address space layout of supervisor memory, U-Mode accesses to S-Mode memory should raise an exception in constant time. The Svukte extension ensures instruction fetches and explicit memory accesses from U-Mode to S-Mode addresses generate page faults independent of the target address, mitigating this timing attack.
 
 [#cat_sr_sub_KTE]
 [width=100%]
@@ -237,7 +237,7 @@ _This extension is not ratified at the time of writing, but is stable enough to 
 protection] specification.*
 
 Supervisor domains allow software components on the same hart to be developed,
-certified, deployed, and attested independently of each other.
+certified, deployed, and attested independently.
 
 A supervisor domain is an S-Mode compartment that is physically isolated from other supervisor domains. The memory,
 execution state and devices belonging to a supervisor domain are isolated from other supervisor domains.
@@ -270,8 +270,8 @@ levels
 
 
 NOTE: The M-Mode resident software responsible for managing context switches and communication between supervisor
-domains is called the Root Domain. Depending on the use case, MPT can
-be sufficient for protecting the Root Domain by enabling M-Mode
+domains is called the Root domain. Depending on the use case, MPT can
+be sufficient for protecting the Root domain by enabling M-Mode
 to ensure that its own resources are never assigned to any another domain.
 PMP/Smepmp may be an additional or alternative protection for M-Mode, enabling the ability to
 implement temporal isolation boundaries within M-Mode (to protect

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -212,6 +212,8 @@ NOTE: Dependent on the use case, Trusted Execution Environments may require or r
 
 ==== Address‑Independent Latency of Faults 
 
+_This extension is not ratified at the time of writing, but is stable enough to be included_
+
 To prevent timing side channels that may infer the address space layout of supervisor memory, U-Mode accesses to S-Mode memory must raise an exception in constant time. The Svukte extension ensures instruction fetches and explicit memory accesses from U-Mode to S-Mode addresses generate page faults independent of the target address, mitigating this timing attack.
 
 [#cat_sr_sub_KTE]
@@ -316,10 +318,12 @@ to a lower trust level supervisor domain. The trust levels/policies are specifie
 security system designer.
 
 | SR_SUD_005
-| Resources assigned to an untrusted supervisor domain MUST be accessible to a trusted supervisor domain
+| Resources assigned to a lower trust levelsupervisor domain MUST be accessible to a higher trust level supervisor domain
 |===
 
-Supervisor domains allow resource isolation and sharing between domains under the control of M-Mode firmware. Trusted Execution Environments can require asymmetric sharing models, where one trusted domain has X/W/R access to other domain's resources.
+Supervisor domains allow resource isolation and sharing between domains under the control of M-Mode firmware. Trusted Execution Environments can require asymmetric sharing models, 
+where one trusted domain has X/W/R access to other domain's resources. 
+
 
 ===== Supervisor domain debug
 
@@ -445,7 +449,7 @@ device-initiated transactions, complementing PMP and SPMP rules.
 | IOPMP MUST be used to guarantee that devices assigned to lower privilege levels cannot access resources assigned to M-Mode.
 
 | SR_IOP_004
-| IOPMP MUST be used to guarantee that devices assigned to a domain cannot be accessed by other domains.
+| IOPMP MUST be used to guarantee that devices assigned to a domain cannot be accessed by other domains unless explicitely authorized 
 
 |===
 
@@ -503,7 +507,7 @@ locations. It complements address translation and protection.
 | Requirement
 
 | SR_IOM_005
-| Systems supporting address translation and protection MUST also support IOMMU
+| Systems supporting address translation and protection MUST support IOMMU
 
 |===
 
@@ -631,7 +635,7 @@ of cryptographic operations at the ISA level. This can both help reduce the TCB 
 an isolated component and also avoid hardware bottlenecks (for example, system
 level cryptographic subsystems).
 
-The entropy source extension provides an ISA level interface to a hardware
+The entropy source extension (Zkr) provides an ISA level interface to a hardware
 entropy source. Entropy source requirements can depend on use case or ecosystem
 specific requirements and RISC-V does not provide any entropy source technical
 specification. However, the entropy source ISA specification does contain general
@@ -773,7 +777,7 @@ The fence.time instruction is a proposed RISC-V ISA extension designed to mitiga
 
 ==== Speculation Barriers
 
-*See https://github.com/riscv/spec-barrier[Speculation Barriers].*
+*See https://github.com/riscv/riscv-spec-barrier[Speculation Barriers].*
 
 Speculative execution attacks exploit vulnerabilities in modern processors that use speculative execution to improve performance. These attacks, such as Spectre and Meltdown, manipulate the CPU's speculative behavior to access sensitive data that should be inaccessible. Although the speculative operations are eventually discarded, the changes they make to system state can be measured and used to infer confidential information. This task group will propose a mechanism for software to signal hardware when not to speculate.
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -709,7 +709,7 @@ For example, architectural metadata storage may be implemented in on-chip memory
 | Requirement
 
 | SR_AMS_004
-| Architectural metadata MUST be isolation by execution context/domain and within domain boundaries
+| Architectural metadata MUST be isolated by execution context/domain and within domain boundaries
 
 |===
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -6,7 +6,7 @@ This chapter outlines brief descriptions of RISC-V security building blocks
 discussed in this specification, together with general guidelines and links to
 technical specifications. The requirement to use a specific mechanism is
 use case dependent. RISC-V has multiple mechanisms that can be used to achieve the
-same goal, the notes associated with SRs indicate where this is the case.
+same goal. The notes associated with SRs indicate where this is the case.
 
 See also the reference use cases chapter of this specification for common
 examples of how RISC-V security building blocks can be combined.
@@ -341,7 +341,7 @@ extensions for interrupts (Smsdia).
 
 | SR_SUD_007
 | A system supporting supervisor domains MUST support supervisor domain
-extensions for external debug (TBD).
+extensions for external debug.
 |===
 
 *See section Smsdia of the https://github.com/riscv/riscv-smmtt[RISC-V Supervisor
@@ -485,7 +485,7 @@ device-initiated memory accesses.
 | IOMPT MUST be used to guarantee that devices assigned to lower privilege levels cannot access resources assigned to M-Mode.
 
 | SR_IOM_004
-| IOMPT MUST be used to guarantee that devices assigned to a domain cannot be accessed by other domains.
+| IOMPT MUST be used to guarantee that resources assigned to a domain cannot be accessed by devices assigned to other domains.
 
 |===
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -53,11 +53,11 @@ and VU-Mode.
 | Requirement
 
 | SR_HYP_001
-| For virtualised environments, Hypervisor extension MUST be supported
+| For virtualized environments, Hypervisor extension MUST be supported
 
 
 | SR_HYP_002
-| For non-virtualised environments, Hypervisor extension MUST be supported
+| For non-virtualized environments, Hypervisor extension MUST be supported
 |===
 
 
@@ -139,7 +139,7 @@ SPMP allows S-Mode to restrict its own access to memory allocated to
 lower privilege levels. This can be used to mitigate against privilege
 escalation attacks, for example.
 
-When combined with H-extension, SPMP and a virtualised SPMP - _vSPMP_ - can be nested so that the hypervisor can
+When combined with H-extension, SPMP and a virtualized SPMP - _vSPMP_ - can be nested so that the hypervisor can
 control memory allocations to its guests, and each guest can control its own
 memory allocations to its workloads.
 
@@ -159,17 +159,18 @@ memory allocations to its workloads.
 | SPMP configurations MUST only be directly accessible to M-Mode and S-Mode
 
 | SR_PMP_007
-| vSPMP configurations MUST only be directly accessible to M-Mode and HS-Mode and VS-mode. 
+| vSPMP configurations MUST only be directly accessible to M-Mode and HS-Mode and VS-Mode. 
 
 | SR_PMP_008
-| vSPMP MUST be used to protect VS-mode from VU-Mode.
+| vSPMP MUST be used to protect VS-Mode from VU-Mode.
 
 | SR_PMP_009
-| vSPMP MUST be used to protect VU-mode workloads from other VU-Mode workloads.
+| vSPMP MUST be used to protect VU-Mode workloads from other VU-Mode workloads.
 
 |===
 
-NOTE: Dependent on the use case, it may be recommended or mandatory to use SPMP to protect S-Mode from lower privilege levels (with or without the H-extension). Address translation and protection may be an additional or alternative mechanism.
+NOTE: Dependent on the use case, it may be recommended or mandatory to use SPMP to protect S-Mode from lower privilege levels (with or without the H-extension). 
+Address translation and protection may be an additional or alternative mechanism.
 
 NOTE: Dependent on the use case, Trusted Execution Environments may require or recommend the use of SPMP to isolate trusted applications from each other.
 Address translation and protection may be an additional or alternative mechanism
@@ -239,7 +240,7 @@ Supervisor domains allow software components on the same hart to be developed,
 certified, deployed, and attested independently of each other.
 
 A supervisor domain is an S-Mode compartment that is physically isolated from other supervisor domains. The memory,
-execution state and devices belonging to a supervisor domains are isolated from other supervisor domains.
+execution state and devices belonging to a supervisor domain are isolated from other supervisor domains.
 This isolation of supervisor domains and the context switching between them is managed by M-Mode firmware.
 
 A supervisor domain is identified at an architecture level by a _Supervisor Domain
@@ -449,7 +450,7 @@ device-initiated transactions, complementing PMP and SPMP rules.
 | IOPMP MUST be used to guarantee that devices assigned to lower privilege levels cannot access resources assigned to M-Mode.
 
 | SR_IOP_004
-| IOPMP MUST be used to guarantee that devices assigned to a domain cannot be accessed by other domains unless explicitely authorized 
+| IOPMP MUST be used to guarantee that devices assigned to a domain cannot be accessed by other domains unless explicitly authorized 
 
 |===
 

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -604,6 +604,15 @@ RISC-V provides two defenses:
 * Shadow stacks (Zicfiss) - protect return addresses on call stacks
 * Labeled Landing pads (Zicfilp) - protect target addresses if indirect jumps
 
+NOTE: NOP-sled and code-injection attacks increase the reliability of control-flow 
+hijacking by allowing redirected execution to land within a broad region of benign 
+instructions that ultimately lead execution to an attacker-controlled payload. 
+RISC-V HINT instructions, as well as other instructions with minimal architecturally 
+visible effects, may be incorporated into NOP-sled-style sequences by an attacker. 
+Detection of such sequences, including those constructed from ISA-defined NOP, HINT, 
+or other NOP-equivalent instruction encodings, is the responsibility of NOP-sled 
+detection software and security tools.
+
 [width=100%]
 [%header, cols="5,20"]
 |===

--- a/specification/src/chapter3.adoc
+++ b/specification/src/chapter3.adoc
@@ -318,7 +318,7 @@ to a lower trust level supervisor domain. The trust levels/policies are specifie
 security system designer.
 
 | SR_SUD_005
-| Resources assigned to a lower trust levelsupervisor domain MUST be accessible to a higher trust level supervisor domain
+| Resources assigned to a lower trust level supervisor domain MUST be accessible to a higher trust level supervisor domain
 |===
 
 Supervisor domains allow resource isolation and sharing between domains under the control of M-Mode firmware. Trusted Execution Environments can require asymmetric sharing models, 

--- a/specification/src/chapter4.adoc
+++ b/specification/src/chapter4.adoc
@@ -8,7 +8,7 @@ This chapter provides a selection of non-exhaustive example security use cases b
 deployment security models. The examples may be extended over time as required. This section is non-normative
 guidance only, detailing the recommended combination of security requirements for the associated use case.
 
-For ease of reference, for each usecase, cite:[rvi::sec-model-map] lists the mapping of the RISC-V
+For ease of reference, for each use case, cite:[rvi::sec-model-map] lists the mapping of the RISC-V
 ISA and non-ISA building blocks used along with links to the building block
 specification, POCs, and code repositories available.
 
@@ -514,7 +514,7 @@ Confidential domain.
 
 In the case of a Global Platform TEE system a rich OS in Normal domain is free
 to schedule services, including TEE services, on any hart available to it. The
-number and make-up of supervisor domains can be known, and a simple convention
+number and composition of supervisor domains can be known, and a simple convention
 can be used for common identification (SDID value, see
 xref:chapter3.adoc#_supervisor_domains[supervisor domains]) of Normal, TEE, and
 Root domains across multiple harts in a system.
@@ -792,7 +792,7 @@ See xref:chapter2.adoc#_attestable_services[attestable services].
 Attestation of confidential workloads is typically layered, for performance and
 separation of concern:
 
-* A security platform attestation, signed by a hardware root of trust
+* A security platform attestation, signed by a HW RoT
 * A confidential workload attestation, signed by TSM
 
 [width=100%]
@@ -865,7 +865,7 @@ to Confidential domain.
 
 ==== System integration
 
-In the case of a confidential compute system, hypervisor in Normal domain
+In the case of a confidential computing system, hypervisor in Normal domain
 typically controls scheduling and resource assignment on the system across all
 harts available to it. The number and make-up of supervisor domains can be
 known, and a simple convention can be used for common identification of Normal,
@@ -889,7 +889,7 @@ workload granularity.
 
 ==== Trusted device assignment
 
-The goal of confidential compute is to provide a minimum TCB for a confidential
+The goal of confidential compute is to provide a minimal TCB for a confidential
 service, and CPU isolation mechanisms discussed so far do that on a hart.
 
 But most confidential services also make use of devices, both on-chip and

--- a/specification/src/chapter4.adoc
+++ b/specification/src/chapter4.adoc
@@ -830,7 +830,7 @@ assets of its own.
 ==== Device access control
 
 For the purpose of this specification, a device can be a logical device. A
-physical device can present more than one logical devices, each with its own
+physical device can present more than one logical device, each with its own
 (logical) control interface.
 
 The security guarantees also apply to device initiated accesses, for example

--- a/specification/src/chapter4.adoc
+++ b/specification/src/chapter4.adoc
@@ -4,7 +4,7 @@
 
 == Use Case Examples - Non Normative
 
-This chapter provides a selection of non-exhaustive example security usecases based on commonly used
+This chapter provides a selection of non-exhaustive example security use cases based on commonly used
 deployment security models. The examples may be extended over time as required. This section is non-normative
 guidance only, detailing the recommended combination of security requirements for the associated use case.
 
@@ -113,7 +113,7 @@ See xref:chapter2.adoc#_sealing[sealing].
 ==== Device access control
 
 For the purpose of this specification, a device can be a logical device. A
-physical device can present one or more logical devices, each with its own
+physical device can present one or more logical device, each with its own
 (logical) control interface.
 
 Isolation guarantees provided to software also apply to device initiated
@@ -387,7 +387,7 @@ The process can involve multiple stages (layered boot).
 | Requirement
 | Reference
 
-| Direct or indirect measurement of a system verifies the software is authorised
+| Direct or indirect measurement of a system verifies the software is authorized
 | SR_MSM_001, SR_MSM_002, SR_MSM_003
 
 | Immutable code ensures a trusted starting point
@@ -474,7 +474,7 @@ domain unique sealing key
 ==== Device access control
 
 For the purpose of this specification, a device can be a logical device. A
-physical device can present one or more logical devices, each with its own
+physical device can present one or more logical device, each with its own
 (logical) control interface.
 
 The security guarantees also apply to device initiated accesses, for example DMA
@@ -764,7 +764,7 @@ been verified:
 * Root domain
 * Boot state of all trusted subsystems
 
-Direct or indirect measurement of a system verifies the software is authorised
+Direct or indirect measurement of a system verifies the software is authorized
 | SR_MSM_001, SR_MSM_002, SR_MSM_003
 
 | Immutable code ensures a trusted starting point
@@ -890,7 +890,7 @@ workload granularity.
 ==== Trusted device assignment
 
 The goal of confidential compute is to provide a minimum TCB for a confidential
-service, and CPU isolation mechanisms discussed so far does that on a hart.
+service, and CPU isolation mechanisms discussed so far do that on a hart.
 
 But most confidential services also make use of devices, both on-chip and
 external. <<_cove_device_access_control, Device virtualization>> can guarantee

--- a/specification/src/chapter4.adoc
+++ b/specification/src/chapter4.adoc
@@ -24,9 +24,9 @@ A generic vertically integrated system can be either virtualized or
 non-virtualized.
 
 
-M-Mode hosts a FW RoT. An OS or a Hypervisor in S-Mode or HS-Mode controls
+M-Mode hosts a FW RoT. An OS or a hypervisor in S-Mode or HS-Mode controls
 applications or guests. Guests and applications execute in U-Mode or VS/VU-Mode and
-trust the OS or Hypervisor to provide isolation guarantees.
+trust the OS or hypervisor to provide isolation guarantees.
 
 
 NOTE: The RISC-V architecture also caters for systems with just M and U modes,
@@ -304,7 +304,7 @@ itself from unintended access to resources assigned to a different domain
 (r/w/x), and to TEE domain (r/w) (default sharing rule)
 | SR_SUD_005
 
-| Ensure resources assigned to a single TA, or a guest TEE, are not be accessible by a
+| Ensure resources assigned to a single TA, or a guest TEE, are not accessible by a
 different TA, or guest TEE, without consent.
 | SR_PMP_005 OR SR_ATP_003
 
@@ -617,7 +617,7 @@ See xref:chapter2.adoc#_event_counters[event counters]
 === Confidential computing on RISC-V (CoVE)
 ==== Overview
 [caption="Figure {counter:image}: ", reftext="Figure {image}"]
-[title= "Confidential compute use case"]
+[title= "Confidential computing use case"]
 image::img_ch4_cove.png[]
 
 In hosting environments, tenant workloads rely on isolation primitives that are
@@ -626,12 +626,12 @@ which may include, for example, a hypervisor, orchestration services, and
 host management services. It may also include other tenants exploiting
 vulnerabilities in complex hosting software.
 
-Confidential compute aims to achieve a minimal and certifiable TCB for
+Confidential computing aims to achieve a minimal and certifiable TCB for
 _confidential workloads_.
 
 _CoVE (Confidential VM Extensions)_
 https://github.com/riscv-non-isa/riscv-ap-tee/tree/main/specification[specification]
-defines a confidential compute platform for RISC-V systems, including
+defines a confidential computing platform for RISC-V systems, including
 interfaces and programming models, covering life cycle management, attestation,
 resource management and devices assignment, for confidential workloads. It is
 based on principles defined by
@@ -867,7 +867,7 @@ to Confidential domain.
 
 In the case of a confidential computing system, hypervisor in Normal domain
 typically controls scheduling and resource assignment on the system across all
-harts available to it. The number and make-up of supervisor domains can be
+harts available to it. The number and composition of supervisor domains can be
 known, and a simple convention can be used for common identification of Normal,
 Confidential, and Root domains across multiple harts in a system.
 
@@ -889,7 +889,7 @@ workload granularity.
 
 ==== Trusted device assignment
 
-The goal of confidential compute is to provide a minimal TCB for a confidential
+The goal of confidential computing is to provide a minimal TCB for a confidential
 service, and CPU isolation mechanisms discussed so far do that on a hart.
 
 But most confidential services also make use of devices, both on-chip and

--- a/specification/src/chapter4.adoc
+++ b/specification/src/chapter4.adoc
@@ -63,7 +63,7 @@ See xref:chapter3.adoc#_spmp[SPMP]
 
 See xref:chapter3.adoc#atp[Address Translation and Protection]
 
-The SPMP is typically used in relatively static deployments such as determinism sensitive use cases like automotives.
+The SPMP is typically used in relatively static deployments such as determinism sensitive use cases like automotive.
 
 The address translation and protection is typically required for Linux based systems and for virtualized systems.
 

--- a/specification/src/chapter4.adoc
+++ b/specification/src/chapter4.adoc
@@ -2,7 +2,7 @@
 
 [[chapter4]]
 
-== Use Case Examples - Non Normative
+== Use Case Examples - Non-Normative
 
 This chapter provides a selection of non-exhaustive example security use cases based on commonly used
 deployment security models. The examples may be extended over time as required. This section is non-normative
@@ -169,7 +169,7 @@ See https://github.com/riscv-non-isa/riscv-external-debug-security[RISC-V extern
 | Allow Debug of non-M-Mode software while blocking debug of higher privilege code
 | SR_DBG_002
 
-| Allow Self-hosted Debug of non M-Mode software
+| Allow Self-hosted Debug of non-M-Mode software
 | SR_DBG_003, SR_DBG_004
 
 |===
@@ -567,7 +567,7 @@ or by Root domain (supervisor domain external debug).
 
 
 
-For example, within normal domain an S-Mode or VS-Mode OS can enable
+For example, within Normal domain an S-Mode or VS-Mode OS can enable
 self-hosted debug for a user application. Or an HS-Mode hypervisor can enable
 self-hosted debug for a VS-Mode guest. Only Root domain should enable
 self-hosted debug for an S-Mode OS or an HS Mode hypervisor.
@@ -779,16 +779,6 @@ Direct or indirect measurement of a system verifies the software is authorized
 
 See xref:chapter2.adoc#_attestable_services[attestable services].
 
-Virtualized TEE attestation can be layered, for performance or separation of
-concern. For example:
-
-* A security platform attestation, signed by a RoT, covering trusted subsystems,
-Root domain, and SPM
-* Separate guest TEE attestation(s) signed by SPM
-
-
-See xref:chapter2.adoc#_attestable_services[attestable services].
-
 Attestation of confidential workloads is typically layered, for performance and
 separation of concern:
 
@@ -830,7 +820,7 @@ assets of its own.
 ==== Device access control
 
 For the purpose of this specification, a device can be a logical device. A
-physical device can present more than one logical device, each with its own
+physical device can present one or more logical device, each with its own
 (logical) control interface.
 
 The security guarantees also apply to device initiated accesses, for example
@@ -945,7 +935,7 @@ or by Root domain (supervisor domain external debug).
 
 |===
 
-For example, within normal domain an HS-Mode hypervisor can enable self-hosted
+For example, within Normal domain an HS-Mode hypervisor can enable self-hosted
 debug for a VS-Mode guest. Only Root domain should enable self-hosted debug for
 the HS-Mode hypervisor.
 

--- a/specification/src/chapter5.adoc
+++ b/specification/src/chapter5.adoc
@@ -29,8 +29,8 @@ systems.
 Quantum safe cryptography is an evolving area of
 researchfootnote:[https://csrc.nist.gov/projects/post-quantum-cryptography].
 
-ML-KEM (FIPS-203), ML-DSA (FIPS-204), and SLH-DSA (FIPS-205). ML-KEM defines a
-key-encapsulation mechanism used to establish a shared secret key over a public
+The first three NIST standardised algorithms are ML-KEM (FIPS-203), ML-DSA (FIPS-204), and SLH-DSA (FIPS-205). 
+ML-KEM defines a key-encapsulation mechanism used to establish a shared secret key over a public
 channel. ML-DSA and SLH-DSA defined digital signature schemes.
 
 RISC-V systems and specifications must at least support a migration path

--- a/specification/src/chapter5.adoc
+++ b/specification/src/chapter5.adoc
@@ -42,11 +42,11 @@ towards use of PQC.
 | ID#
 | Requirement
 
-| SR_CPT_003
+| SR_CPT_004
 | In applications which require a migration path to PQC algorithms, all
 immutable components SHOULD support PQC alternatives.
 
-| SR_CPT_004
+| SR_CPT_005
 | All mutable components MUST at least have a migration path to quantum safe
 cryptography.
 

--- a/specification/src/contributors.adoc
+++ b/specification/src/contributors.adoc
@@ -1,7 +1,7 @@
 == Contributors
 
 This RISC-V specification has been contributed to directly or indirectly by (in
-alphabetical order): Ali Zhang, Andy Dellow, Carl Shaw, Colin O'Flynn, Dean
+alphabetical order): Ali Zhang, Andrew Dellow, Carl Shaw, Colin O'Flynn, Dean
 Liberty, Dong Du, Deepak Gupta, Fabrice Marinet, Guerney Hunt, Luis Fiolhais,
 Manuel Offenberg, Markku Juhani Saarinen, Munir Geden, Mark Hill, Nicholas Wood
 (editor), Paul Elliott, Ravi Sahita (co-editor), Robin Randhawa, Samuel Ortiz,

--- a/specification/src/header.adoc
+++ b/specification/src/header.adoc
@@ -1,8 +1,8 @@
 [[header]]
 :description: RISC-V Security Model
 :company: RISC-V.org
-:revdate: 03/2025
-:revnumber: 0.4
+:revdate: 07/2026
+:revnumber: 0.61
 :revremark: This document is in development. Assume everything can change. See http://riscv.org/spec-state for details.
 :url-riscv: http://riscv.org
 :doctype: book


### PR DESCRIPTION
typo, american spellings, plurality on some words. duplicate SR_CPT_003